### PR TITLE
The fire method was removed in 5.8

### DIFF
--- a/src/FirebaseChannel.php
+++ b/src/FirebaseChannel.php
@@ -65,7 +65,7 @@ class FirebaseChannel
                 $this->client->send($message);
             }
         } catch (Exception $e) {
-            $this->events->fire(
+            $this->events->dispatch(
                 new NotificationFailed($notifiable, $notification, $this)
             );
         }


### PR DESCRIPTION
From the 5.8 upgrade docs:
The fire method (which was deprecated in Laravel 5.4) of the Illuminate/Events/Dispatcher class has been removed. You should use the dispatch method instead.