### PR TITLE
routeNotificationForFirebase checks

### DIFF
--- a/src/FirebaseChannel.php
+++ b/src/FirebaseChannel.php
@@ -57,6 +57,10 @@ class FirebaseChannel
             return;
         }
 
+        if (!is_array($devices)) {
+            throw new Exception('Firebase notification method "routeNotificationForFirebase" in ' . $notifiable->getTable() . ' should return an array');
+        }
+
         $firebase = $notification->toFirebase($notifiable);
 
         try {

--- a/src/FirebaseChannel.php
+++ b/src/FirebaseChannel.php
@@ -49,6 +49,10 @@ class FirebaseChannel
     {
         $devices = $notifiable->routeNotificationFor('firebase');
 
+        if (!method_exists($notifiable, 'routeNotificationForFirebase')) {
+            throw new Exception('Firebase notification method "routeNotificationForFirebase" is not implemented but was called for ' . $notifiable->getTable());
+        }
+
         if (empty($devices)) {
             return;
         }


### PR DESCRIPTION
Was doing some refactoring and these two bit me. 

The missing method in the model when called & the catch method silently catches `Invalid argument supplied for foreach()` if devices is not an array.